### PR TITLE
Feat/residential register

### DIFF
--- a/app/Helpers/SanitizeString.php
+++ b/app/Helpers/SanitizeString.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Helpers;
+
+class SanitizeString
+{
+    public static function run(string $dirty)
+    {
+        if (is_string($dirty)) {
+            return strip_tags($dirty);
+        }
+        return "";
+    }
+}

--- a/app/Helpers/SanitizeString.php
+++ b/app/Helpers/SanitizeString.php
@@ -1,13 +1,17 @@
 <?php
+
 namespace App\Helpers;
 
 class SanitizeString
 {
-    public static function run(string $dirty)
-    {
-        if (is_string($dirty)) {
-            return strip_tags($dirty);
+    public static function run(?string $dirty): string{
+        if (!is_string($dirty)) {
+            return "";
         }
-        return "";
+        $clean = trim($dirty);
+        $clean = strip_tags($clean);
+        $clean = htmlspecialchars($clean, ENT_QUOTES);
+        $clean = preg_replace('/\s+/', ' ', $clean);
+        return $clean;
     }
 }

--- a/app/Helpers/UserValidator.php
+++ b/app/Helpers/UserValidator.php
@@ -1,0 +1,9 @@
+<?php
+
+class UserValidator {
+
+    private static array $permitidos = ['admin', 'vigilante', 'residente'];
+    public static function validateRol(string $rol){
+        return in_array($rol, self::$permitidos);
+    }
+}

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use DateTime;
+use Illuminate\Http\Request;
+use App\Models\Tenants;
+use Str;
+
+class TenantController extends Controller
+{
+    public function registerTenant(Request $request){
+        $nombre_residencial = $request->input('nombre_residencial');
+        $ACTIVO = false;
+        $tenant = Tenants::create([
+            'id' => Str::uuid(),
+            'nombre_residencial' => $nombre_residencial,
+            'plan_id' => null,
+            'stripe_customer_id' => null,
+            'activo' => $ACTIVO
+        ]);
+        $tenant->save();
+        return response()->json([
+            "activo" => $ACTIVO,
+            "nombre residencial" => $nombre_residencial,
+            "message" => "la ruta ha funcionado",
+            "data" => $tenant->toArray()
+        ], 200, ["mi header" => "holaaaaaa"]);
+    }
+}

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -3,29 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use DateTime;
 use Illuminate\Http\Request;
-use App\Models\Tenants;
-use Str;
+use App\Services\TenantServices;
 
 class TenantController extends Controller
 {
     public function registerTenant(Request $request){
-        $nombre_residencial = $request->input('nombre_residencial');
-        $ACTIVO = false;
-        $tenant = Tenants::create([
-            'id' => Str::uuid(),
-            'nombre_residencial' => $nombre_residencial,
-            'plan_id' => null,
-            'stripe_customer_id' => null,
-            'activo' => $ACTIVO
-        ]);
-        $tenant->save();
-        return response()->json([
-            "activo" => $ACTIVO,
-            "nombre residencial" => $nombre_residencial,
-            "message" => "la ruta ha funcionado",
-            "data" => $tenant->toArray()
-        ], 200, ["mi header" => "holaaaaaa"]);
+        return TenantServices::register($request);
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,7 +8,7 @@ use App\Services\UserServices;
 
 class UserController extends Controller
 {
-    public function register(Request $request){
-        return UserServices::register($request);
+    public function RegisterResidentialAdmin(Request $request){
+        return UserServices::RegisterResidentialAdmin($request);
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Services\UserServices;
+
+class UserController extends Controller
+{
+    public function register(Request $request){
+        return UserServices::register($request);
+    }
+}

--- a/app/Services/TenantServices.php
+++ b/app/Services/TenantServices.php
@@ -44,7 +44,7 @@ class TenantServices {
             ]);
             return response()->json([
                 'message' => 'nuevo tenant creado con exito.'
-            ], 201);
+            ], 201)->cookie('tenant_id', $tenant->id, 30, null, null, true, true);
         }catch(Throwable $error){
             $error_message = $error->getMessage();
             return response()->json([

--- a/app/Services/TenantServices.php
+++ b/app/Services/TenantServices.php
@@ -22,8 +22,9 @@ class TenantServices {
                 ],422);
             }
             $ACTIVO = false;
+            $nombre_residencial_formateado = Str::title($nombre_residencial_sanitizado);
 
-            $storedSameTenant = Tenants::where('nombre_residencial', $nombre_residencial)->first();
+            $storedSameTenant = Tenants::where('nombre_residencial', $nombre_residencial_formateado)->first();
 
             if($storedSameTenant){
                 return response()->json([
@@ -34,7 +35,7 @@ class TenantServices {
 
             $tenant = Tenants::create([
                 'id' => Str::uuid(),
-                'nombre_residencial' => Str::title($nombre_residencial_sanitizado),
+                'nombre_residencial' => $nombre_residencial_formateado,
                 'plan_id' => null,
                 'stripe_customer_id' => null,
                 'activo' => $ACTIVO,

--- a/app/Services/TenantServices.php
+++ b/app/Services/TenantServices.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Request;
+use App\Models\Tenants;
+use App\Helpers\SanitizeString;
+use Str;
+use Throwable;
+
+class TenantServices {
+    public static function register(Request $request){
+        $response = [];
+        try{
+            $nombre_residencial = $request->input('nombre_residencial');
+            $nombre_residencial_sanitizado = SanitizeString::run($nombre_residencial);
+            if($nombre_residencial_sanitizado === "" || $nombre_residencial_sanitizado !== $nombre_residencial){
+                return response()->json([
+                    'success' => false,
+                    'message' => 'el nombre de la residencial es invalido porque contiene codigo malicioso.'
+                ]);
+            }
+            $ACTIVO = false;
+            $tenant = Tenants::create([
+                'id' => Str::uuid(),
+                'nombre_residencial' => $nombre_residencial_sanitizado,
+                'plan_id' => null,
+                'stripe_customer_id' => null,
+                'activo' => $ACTIVO,
+                'fecha_inicio' => null,
+                'fecha_fin' => null
+            ]);
+            return response()->json([
+                'success' => true,
+                'message' => 'nuevo tenant creado con exito.'
+            ], 201);
+        }catch(Throwable $error){
+            $error_message = $error->getMessage();
+            return response()->json([
+                'success' => false,
+                'message' => "Error: $error_message"
+            ], 500);
+        }
+    }
+}

--- a/app/Services/UserServices.php
+++ b/app/Services/UserServices.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Hash;
 use App\Helpers\SanitizeString;
@@ -16,13 +17,12 @@ class UserServices {
             $validated = $request->validate([
                 'nombre' => 'required|string',
                 'email' => 'required|email|unique:users,email',
-                'password' => 'required|min:8',
-                'tenant_id' => 'required|uuid'
+                'password' => 'required|min:8'
             ]);
+            $tenant_id = $request->cookie('tenant_id');
             $nombre = SanitizeString::run($validated['nombre']);
             $email = SanitizeString::run($validated['email']);
             $password = $validated['password'];
-            $tenant_id = $validated['tenant_id'];
             $ROL = 'admin';
 
             $newUserAttr = [
@@ -38,7 +38,7 @@ class UserServices {
 
             return response()->json([
                 'message' => 'Usuario registrado con éxito.'
-            ], 201);
+            ], 201)->cookie(Cookie::forget('tenant_id'));
         } catch (Throwable $error) {
             $error_message = $error->getMessage();
             return response()->json([

--- a/app/Services/UserServices.php
+++ b/app/Services/UserServices.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use App\Helpers\SanitizeString;
+use App\Models\Users;
+use Throwable;
+use UserValidator;
+
+class UserServices {
+    public static function register(Request $request){
+        try {
+            $request->validate([
+                'email' => 'required|email'
+            ]);
+            $nombre = SanitizeString::run($request->input('nombre'));
+            $email = SanitizeString::run($request->input('email'));
+            $password = $request->input('password');
+            $rol = $request->input('rol', null);
+
+            if ($nombre === "" || $email === "" || empty($password)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Nombre, email y contraseña son requeridos y deben ser válidos.'
+                ], 400);
+            }
+
+            $newUserAttr = [
+                'id' => Str::uuid(),
+                'tenant_id' => null,
+                'nombre' => $nombre,
+                'email' => $email,
+                'password_hash' => Hash::make($password)
+            ];
+
+            if ($rol) {
+                if(UserValidator::validateRol($rol)){
+                    $newUserAttr['rol'] = $rol;
+                } else {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'No tienes permisos para asignarte este rol.'
+                    ], 403);
+                }
+            }
+
+            Users::create($newUserAttr);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Usuario registrado con éxito.'
+            ], 201);
+        } catch (Throwable $error) {
+            $error_message = $error->getMessage();
+            return response()->json([
+                'success' => false,
+                'message' => "Error: $error_message"
+            ], 500);
+        }
+    }
+
+    public static function registerInTenant(Request $request){
+        
+    }
+}

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => ['http://localhost:5173'], //para desarrollo
 
     'allowed_origins_patterns' => [],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,4 +22,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::post('/tenants/register', [TenantController::class, 'registerTenant']);
 
-Route::post('/users/register', [UserController::class, 'register']);
+Route::post('/users/register-admin', [UserController::class, 'RegisterResidentialAdmin']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TenantController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +18,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('/Tenants/register', [TenantController::class, 'registerTenant']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TenantController;
@@ -19,4 +20,6 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('/Tenants/register', [TenantController::class, 'registerTenant']);
+Route::post('/tenants/register', [TenantController::class, 'registerTenant']);
+
+Route::post('/users/register', [UserController::class, 'register']);


### PR DESCRIPTION
- El registro de tenants ahora devuelve el tenant_id en una cookie httpOnly.
- El registro de usuarios administradores usará esta cookie para asociar el usuario al tenant correcto.
- CORS ahora permite específicamente la ruta http://localhost:5173 para evitar problemas en fase de desarrollo.